### PR TITLE
make a better grunt dot

### DIFF
--- a/tasks/tb_grunt_dot.js
+++ b/tasks/tb_grunt_dot.js
@@ -13,15 +13,17 @@ module.exports = function(grunt) {
   grunt.registerMultiTask('tb_grunt_dot', 'An dot builder to be used under grunt.', function() {
     // Merge task-specific and/or target-specific options with these defaults.
 
-    var options = this.options();
-    options.ext = options.ext || '.dot'
+    var options = this.options({
+      ext: '.html',
+      amd: true
+    });
 
     this.files.forEach(function(f) {
-      var files = f.src.filter(function(filepath) {
+      var files = f.src.filter(function(srcFilePath) {
         // Warn on and remove invalid source files (if nonull was set).
-        if (grunt.file.isDir(filepath)) return false;
-        if (!grunt.file.exists(filepath)) {
-          grunt.log.warn('Source file "' + filepath + '" not found.');
+        if (grunt.file.isDir(srcFilePath)) return false;
+        if (!grunt.file.exists(srcFilePath)) {
+          grunt.log.warn('Source file "' + srcFilePath + '" not found.');
           return false;
         } else {
           return true;
@@ -29,20 +31,24 @@ module.exports = function(grunt) {
       });
 
       if (!files.length) return;
-      files.map(function(filepath) {
-        var originalContent = grunt.file.read(filepath);
-        try {
-          originalContent = doT.template(originalContent).toString();
-          // make template amd ready
-          if (options.amd) {
-            originalContent = 'define([],function(){return ' + originalContent + '});';
-          }
-          filepath = filepath.replace(options.ext, '.js')
-          grunt.file.write(filepath, originalContent);
-        } catch (e) {
-          grunt.log.error('Source file "' + filepath + '" error.', e);
+
+      var originalContent = files.map(function(srcFilePath) {
+        return grunt.file.read(srcFilePath);
+      }).join('');
+
+      var destFilePath = f.dest.replace(options.ext, '.js')
+
+      try {
+        originalContent = doT.template(originalContent).toString();
+        // make template amd ready
+        if (options.amd) {
+          originalContent = 'define([],function(){return ' + originalContent + '});';
         }
-      });
+        grunt.file.write(destFilePath, originalContent);
+      } catch (e) {
+        grunt.log.error('Source file "' + f.src + '" error.', e);
+      }
+
     });
   });
 


### PR DESCRIPTION
this.files的结构是这样的：

```
[{
    "src": ["src/templates/basic.html"],
    "dest": "lib/templates/basic.html",
    "orig": {
        "expand": true,
        "cwd": "src/",
        "src": ["**/*.html"],
        "dest": "lib/"
    }
}]
[{
    "src": ["src/templates/task.html", "src/templates/event.html"],
    "dest": "lib/templates/task.js",
    "orig": {
        "src": ["src/templates/task.html", "src/templates/event.html"],
        "dest": "lib/templates/task.js"
    }
}]
```

我目前的做法是把src合到一起，define成一个模块
